### PR TITLE
Fixes NTP server address key position

### DIFF
--- a/pkg/connectgnmi/getgnmi.go
+++ b/pkg/connectgnmi/getgnmi.go
@@ -33,7 +33,7 @@ func Get(Target, Port, Username, Password string) {
 		Username: Username,
 		Password: Password,
 	}
-	paths := []string{"/openconfig-system:system/ntp/servers/server/config[address=*]"}
+	paths := []string{"/openconfig-system:system/ntp/servers/server[address=*]/config"}
 	var origin = "openconfig"
 	ctx := gnmi.NewContext(context.Background(), cfg)
 	client, err := gnmi.Dial(cfg)


### PR DESCRIPTION
Fixes error when running this as the "address" key should be on server rather than config:

```
rpc error: code = InvalidArgument desc = error getting /openconfig-system:system/ntp/servers/server/config[address=*]: path invalid: invalid key "address" for node "config"
exit status 1
```

